### PR TITLE
Removed free artwork profiles

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -446,16 +446,6 @@
               </div>
               <div class="profile_group profile_primary_group">
                 <div class="profile_group_avatar">
-                  <a href="https://steamcommunity.com/groups/FreeArtwork">
-                    <img src="https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/07/07371a76a92abf8fb481a8921b9f0888012e1a4f_medium.jpg">
-                  </a>
-                </div>
-                <a class="whiteLink" href="https://steamcommunity.com/groups/FreeArtwork">Free Artwork</a>
-                <div class="profile_group_membercount">A bot that makes free animated art!</div>
-                <div style="clear: left;"></div>
-              </div>
-              <div class="profile_group profile_primary_group">
-                <div class="profile_group_avatar">
                   <a href="https://steamcommunity.com/groups/ArtworkProfiles">
                     <img src="https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/a8/a8dbf5dc460745146602a2e9b61b25d7aebfed09_medium.jpg">
                   </a> </div>


### PR DESCRIPTION
Very likely the project is dead.

The current group that has url is now "don't join this fucking group."