### PR TITLE
Issue # 44: changed preview and download to use the correct xvalues

### DIFF
--- a/src/components/pages/index/Preview.vue
+++ b/src/components/pages/index/Preview.vue
@@ -30,8 +30,9 @@
                         .screenshot_showcase_screenshot
                           .profile_main_artbox(:style="{ \
                             backgroundImage: `url('${$store.state.background}')`,\
-                            width: `${$store.state.bgSize.w}px`,\
-                            height: `${$store.state.bgSize.h - 272}px`\
+                            width: `${$store.state.bgSize.w - 228}px`,\
+                            height: `${$store.state.bgSize.h - 272}px`,\
+                            backgroundPosition: `${($store.state.bgSize.w / 2) + 451}px -271px` \
                           }")
                         .screenshot_showcase_itemname
                       .screenshot_showcase_rightcol
@@ -39,8 +40,9 @@
                           .screenshot_showcase_screenshot
                             .profile_main_artbox_side1(:style="{ \
                               backgroundImage: `url('${$store.state.background}')`,\
-                              width: `${$store.state.bgSize.w}px`,\
-                              height: `${$store.state.bgSize.h - 272}px`\
+                              width: `${$store.state.bgSize.w - 228}px`,\
+                              height: `${$store.state.bgSize.h - 272}px`,\
+                              backgroundPosition: `${($store.state.bgSize.w / 2) - 63}px -271px` \
                             }")
                             // <img width="100%" style="max-width: 100px;" :src="$store.state.background">
 
@@ -58,7 +60,7 @@ export default {
 .profile_main_artbox
   width 100%
   height 850px
-  background-position -508px -271px
+  /**background-position-y -508px -271px**/
 
 .profile_header_bg
   background $color-main-transparent
@@ -84,7 +86,6 @@ export default {
 .profile_main_artbox_side1
   width 100%
   height 850px
-  background-position -1022px -271px
 
 .profile_customization
   background-color transparent

--- a/src/components/pages/index/Preview.vue
+++ b/src/components/pages/index/Preview.vue
@@ -32,7 +32,7 @@
                             backgroundImage: `url('${$store.state.background}')`,\
                             width: `${$store.state.bgSize.w}px`,\
                             height: `${$store.state.bgSize.h - 272}px`,\
-                            backgroundPosition: `${($store.state.bgSize.w / 2) + 451}px -271px` \
+                            backgroundPosition: `${($store.state.bgSize.w / 2) + 451}px -272px` \
                           }")
                         .screenshot_showcase_itemname
                       .screenshot_showcase_rightcol
@@ -42,7 +42,7 @@
                               backgroundImage: `url('${$store.state.background}')`,\
                               width: `${$store.state.bgSize.w}px`,\
                               height: `${$store.state.bgSize.h - 272}px`,\
-                              backgroundPosition: `${($store.state.bgSize.w / 2) - 63}px -271px` \
+                              backgroundPosition: `${($store.state.bgSize.w / 2) - 63}px -272px` \
                             }")
                             // <img width="100%" style="max-width: 100px;" :src="$store.state.background">
 

--- a/src/components/pages/index/Preview.vue
+++ b/src/components/pages/index/Preview.vue
@@ -30,7 +30,7 @@
                         .screenshot_showcase_screenshot
                           .profile_main_artbox(:style="{ \
                             backgroundImage: `url('${$store.state.background}')`,\
-                            width: `${$store.state.bgSize.w - 228}px`,\
+                            width: `${$store.state.bgSize.w}px`,\
                             height: `${$store.state.bgSize.h - 272}px`,\
                             backgroundPosition: `${($store.state.bgSize.w / 2) + 451}px -271px` \
                           }")
@@ -40,7 +40,7 @@
                           .screenshot_showcase_screenshot
                             .profile_main_artbox_side1(:style="{ \
                               backgroundImage: `url('${$store.state.background}')`,\
-                              width: `${$store.state.bgSize.w - 228}px`,\
+                              width: `${$store.state.bgSize.w}px`,\
                               height: `${$store.state.bgSize.h - 272}px`,\
                               backgroundPosition: `${($store.state.bgSize.w / 2) - 63}px -271px` \
                             }")
@@ -60,7 +60,6 @@ export default {
 .profile_main_artbox
   width 100%
   height 850px
-  /**background-position-y -508px -271px**/
 
 .profile_header_bg
   background $color-main-transparent

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -134,8 +134,8 @@ const actions = {
       images: [
         { name: 'Artwork_Middle.png', x: (state.bgSize.w / 2) - 466, y: 256, w: 506, h: 2000 },
         { name: 'Artwork_Right_Top.png', x: (state.bgSize.w / 2) + 49, y: 256, w: 100, h: 2000 },
-        { name: 'Artwork_Featured.png', x: 492, y: 256, w: 630, h: 2000 },
-        { name: 'Avatar.png', x: 499, y: 34, w: 164, h: 164 },
+        { name: 'Artwork_Featured.png', x: (state.bgSize.w / 2) - 466, y: 256, w: 630, h: 2000 },
+        { name: 'Avatar.png', x: (state.bgSize.w / 2) - 463, y: 34, w: 164, h: 164 },
       ],
     }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -132,8 +132,8 @@ const actions = {
     const bgSaveInfo = {
       url: state.background,
       images: [
-        { name: 'Artwork_Middle.png', x: 492, y: 256, w: 506, h: 2000 },
-        { name: 'Artwork_Right_Top.png', x: 1006, y: 256, w: 100, h: 2000 },
+        { name: 'Artwork_Middle.png', x: (state.bgSize.w / 2) - 466, y: 256, w: 506, h: 2000 },
+        { name: 'Artwork_Right_Top.png', x: (state.bgSize.w / 2) + 49, y: 256, w: 100, h: 2000 },
         { name: 'Artwork_Featured.png', x: 492, y: 256, w: 630, h: 2000 },
         { name: 'Avatar.png', x: 499, y: 34, w: 164, h: 164 },
       ],


### PR DESCRIPTION
Changed preview and download to use the middle of the background + the offset of the left sides from the middle as xvalue.
The difference in offset values from download to preview is because of the misalignment of the background from issue#46

more testing recommended before deployed.